### PR TITLE
Node IDs Longer Than One Character Do Not Work

### DIFF
--- a/js/treeData.js
+++ b/js/treeData.js
@@ -15,7 +15,7 @@ function buildTree (obj, node) {
     var sons = [];
     for (var i in obj) {
         if (obj[i].parent == node)
-          sons += i;
+          sons.push(i);
     }
     if (sons.length > 0) {
         treeString += "<ul>";


### PR DESCRIPTION
In the current version, 'sons' is being treated as a string, and 'i' is being concatenated to it. However, 'sons' should be an array, and 'i' should be pushed into it using the 'push()' method. Therefore, the correct line of code should be sons.push(i). With this modification, the script works for node ids of any length.